### PR TITLE
Refactor codec

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -52,7 +52,7 @@ func EncodeCandidates(plain string) ([]string, error) {
 }
 
 func key(word string) int {
-	i := score(word) - len(word)
+	i := score(word)
 	if i <= 0 {
 		return 0
 	}
@@ -62,7 +62,7 @@ func key(word string) int {
 func score(word string) int {
 	var s int32
 	for _, char := range word {
-		s += char + 1 - 'a'
+		s += char - 'a'
 	}
 	return int(s)
 }

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -15,13 +15,12 @@ func DecodeCandidates(encoded string) ([]string, error) {
 		return nil, fmt.Errorf(`[a-z] characters can be used: "%s"`, encoded)
 	}
 	var candidates []string
-	cand := encoded
 	// Not 26
 	for i := 0; i < 25; i++ {
+		cand := shift(encoded, -i)
 		if i == key(cand) {
 			candidates = append(candidates, cand)
 		}
-		cand = shift(cand, -1)
 	}
 	return candidates, nil
 }


### PR DESCRIPTION
- DecodeCandidates の for 文で、毎回 encoded から shift するほうが直感的だと思われるので、修正した
- score の出し方で、runeごと毎回+1しているが、後で使われず減算されてるので、最初からたさない用に修正した